### PR TITLE
Create arm64.src

### DIFF
--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,0 +1,6 @@
+SOURCE_URL=https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.106.3/AdGuardHome_linux_arm64.tar.gz
+SOURCE_SUM=67985e90dc5e7a6a96b0cbbb9f75139980b374aa795eca7d92ed06d8b3aa0bcd
+SOURCE_SUM_PRG=sha256sum
+SOURCE_FORMAT=tar.gz
+SOURCE_IN_SUBDIR=2
+SOURCE_EXTRACT=true


### PR DESCRIPTION
## Problem
Arm64 archi has no source file #23 

## Solution
Add source file for arm64

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested

Edit : just installed it with `sudo yunohost app install https://github.com/Quiwy/adguardhome_ynh`

```
Info: Installing adguardhome...
Info: [....................] > Validating installation parameters...
Info: [++..................] > Storing installation settings...
Info: [##+.................] > Finding an available port...
Info: [###+................] > Installing dependencies...
Info: [####+...............] > Configuring system user...
Info: [#####++++...........] > Setting up source files...
Info: [#########++.........] > Configuring NGINX web server...
Info: [###########+........] > Modifying a config file...
Info: [############+.......] > Configuring a systemd service...
Info: [#############+......] > Integrating service in YunoHost...
Info: [##############++....] > Starting a systemd service...
Info: [################+...] > Configuring permissions...
Info: [#################++.] > Reloading NGINX web server...
Info: [####################] > Installation of adguardhome completed
Success! Installation completed
```

And I've the following output and everything seems working.

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
