### PR TITLE
Testing v0.107.37

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -27,8 +27,8 @@ ynh_print_info --message="Loading installation settings..."
 
 app=$YNH_APP_INSTANCE_NAME
 
-final_path=$(ynh_app_setting_get --app=$app --key=final_path)
-domain=$(ynh_app_setting_get --app=$app --key=domain)
+final_path=$(ynh_app_setting_get --app="$app" --key=final_path)
+domain=$(ynh_app_setting_get --app="$app" --key=domain)
 
 #=================================================
 # DECLARE DATA AND CONF FILES TO BACKUP

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -27,8 +27,8 @@ app=$YNH_APP_INSTANCE_NAME
 ynh_script_progression --message="Loading installation settings..." --weight=1
 
 # Needed for helper "ynh_add_nginx_config"
-final_path=$(ynh_app_setting_get --app=$app --key=final_path)
-port=$(ynh_app_setting_get --app=$app --key=port)
+final_path=$(ynh_app_setting_get --app="$app" --key=final_path)
+port=$(ynh_app_setting_get --app="$app" --key=port)
 
 #=================================================
 # BACKUP BEFORE CHANGE URL THEN ACTIVE TRAP
@@ -70,7 +70,7 @@ fi
 #=================================================
 ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="stop"
+ynh_systemd_action --service_name="$app" --action="stop"
 
 #=================================================
 # MODIFY URL IN NGINX CONF
@@ -96,7 +96,7 @@ if [ $change_domain -eq 1 ]
 then
 	# Delete file checksum for the old conf file location
 	ynh_delete_file_checksum --file="$nginx_conf_path"
-	mv $nginx_conf_path /etc/nginx/conf.d/$new_domain.d/$app.conf
+	mv "$nginx_conf_path" "/etc/nginx/conf.d/$new_domain.d/$app.conf"
 	# Store file checksum for the new config file location
 	ynh_store_file_checksum --file="/etc/nginx/conf.d/$new_domain.d/$app.conf"
 fi
@@ -108,7 +108,7 @@ fi
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="start"
+ynh_systemd_action --service_name="$app" --action="start"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/install
+++ b/scripts/install
@@ -36,37 +36,37 @@ app=$YNH_APP_INSTANCE_NAME
 #=================================================
 ynh_script_progression --message="Validating installation parameters..." --weight=1
 
-final_path=/var/www/$app
+final_path="/var/www/$app"
 test ! -e "$final_path" || ynh_die --message="This path already contains a folder"
 
 # Register (book) web path
-ynh_webpath_register --app=$app --domain=$domain --path_url=$path_url
+ynh_webpath_register --app="$app" --domain="$domain" --path_url="$path_url"
 
 #=================================================
 # STORE SETTINGS FROM MANIFEST
 #=================================================
 ynh_script_progression --message="Storing installation settings..." --weight=2
 
-ynh_app_setting_set --app=$app --key=domain --value=$domain
-ynh_app_setting_set --app=$app --key=path --value=$path_url
-ynh_app_setting_set --app=$app --key=admin --value=$admin
+ynh_app_setting_set --app="$app" --key=domain --value="$domain"
+ynh_app_setting_set --app="$app" --key=path --value="$path_url"
+ynh_app_setting_set --app="$app" --key=admin --value="$admin"
 
 if [ "$dns_over_https" == "1" ];
 then
     dns_over_https="true"
     # DNS over TLS
     adguard_DoT_port=853
-    ynh_app_setting_set --app=$app --key=adguard_DoT_port --value=$adguard_DoT_port
+    ynh_app_setting_set --app="$app" --key=adguard_DoT_port --value=$adguard_DoT_port
     ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $adguard_DoT_port
     ynh_exec_warn_less yunohost firewall allow --no-upnp TCP $adguard_DoT_port
     # DNS over QUIC
     adguard_DoQ_port=784
-    ynh_app_setting_set --app=$app --key=adguard_DoQ_port --value=$adguard_DoQ_port
+    ynh_app_setting_set --app="$app" --key=adguard_DoQ_port --value=$adguard_DoQ_port
     ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $adguard_DoQ_port
 else
     dns_over_https="false"
 fi
-ynh_app_setting_set --app=$app --key=dns_over_https --value=$dns_over_https
+ynh_app_setting_set --app="$app" --key=dns_over_https --value=$dns_over_https
 
 #=================================================
 # STANDARD MODIFICATIONS
@@ -77,11 +77,11 @@ ynh_script_progression --message="Finding an available port..." --weight=1
 
 # Find an available port
 port=$(ynh_find_port --port=3000)
-ynh_app_setting_set --app=$app --key=port --value=$port
+ynh_app_setting_set --app="$app" --key=port --value="$port"
 
 # Find an available port
 adguard_port=53
-ynh_app_setting_set --app=$app --key=adguard_port --value=$adguard_port
+ynh_app_setting_set --app="$app" --key=adguard_port --value=$adguard_port
 
 # Disable the port 53 for upnp
 ynh_exec_warn_less yunohost firewall allow --no-upnp TCP $adguard_port
@@ -92,7 +92,7 @@ ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $adguard_port
 #=================================================
 ynh_script_progression --message="Installing dependencies..." --weight=1
 
-ynh_install_app_dependencies $pkg_dependencies
+ynh_install_app_dependencies "$pkg_dependencies"
 
 #=================================================
 # CREATE DEDICATED USER
@@ -100,22 +100,22 @@ ynh_install_app_dependencies $pkg_dependencies
 ynh_script_progression --message="Configuring system user..." --weight=1
 
 # Create a system user
-ynh_system_user_create --username=$app --home_dir="$final_path" --groups="ssl-cert"
+ynh_system_user_create --username="$app" --home_dir="$final_path" --groups="ssl-cert"
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 ynh_script_progression --message="Setting up source files..." --weight=4
 
-ynh_app_setting_set --app=$app --key=final_path --value=$final_path
+ynh_app_setting_set --app="$app" --key=final_path --value="$final_path"
 # Download, check integrity, uncompress and patch the source from app.src
-ynh_setup_source --dest_dir=$final_path --source_id="$YNH_ARCH"
+ynh_setup_source --dest_dir="$final_path" --source_id="$YNH_ARCH"
 
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
-chown -R $app:$app "$final_path"
+chown -R "$app":"$app" "$final_path"
 
-setcap 'CAP_NET_BIND_SERVICE=+eip CAP_NET_RAW=+eip' $final_path/AdGuardHome
+setcap 'CAP_NET_BIND_SERVICE=+eip CAP_NET_RAW=+eip' "$final_path"/AdGuardHome
 
 #=================================================
 # NGINX CONFIGURATION
@@ -158,31 +158,31 @@ ipv4_route_output=$(echo "$(ip -4 route get 1.2.3.4 2> /dev/null)" | head -n1 | 
 ipv6_route_output=$(echo "$(ip -6 route get ::1.2.3.4 2> /dev/null)" | head -n1)
 
 ipv4_addr=""
-for i in $(seq "$(echo $ipv4_route_output | wc -w)" -1 1); do
-    ip=$(echo $ipv4_route_output | awk "{print \$$i}")
-    if ynh_validate_ip4 --ip_address=$ip; then
+for i in $(seq "$(echo "$ipv4_route_output" | wc -w)" -1 1); do
+    ip=$(echo "$ipv4_route_output" | awk "{print \$$i}")
+    if ynh_validate_ip4 --ip_address="$ip"; then
         ipv4_addr="- $ip"
         break
     fi
 done
 
 ipv6_addr=""
-for i in $(seq "$(echo $ipv6_route_output | wc -w)" -1 1); do
-    ip=$(echo $ipv6_route_output | awk "{print \$$i}")
-    if ynh_validate_ip6 --ip_address=$ip; then
+for i in $(seq "$(echo "$ipv6_route_output" | wc -w)" -1 1); do
+    ip=$(echo "$ipv6_route_output" | awk "{print \$$i}")
+    if ynh_validate_ip6 --ip_address="$ip"; then
         ipv6_addr="- $ip"
         break
     fi
 done
 
 password=$(python3 -c "import bcrypt; print(bcrypt.hashpw(b\"$password\", bcrypt.gensalt(rounds=10)).decode())")
-ynh_app_setting_set --app=$app --key=password --value=$password
+ynh_app_setting_set --app="$app" --key=password --value="$password"
 
 # Main config File
 ynh_add_config --template="../conf/AdGuardHome.yaml" --destination="$final_path/AdGuardHome.yaml"
 
 chmod 600 "$final_path/AdGuardHome.yaml"
-chown -R $app:$app "$final_path/AdGuardHome.yaml"
+chown -R "$app":"$app" "$final_path/AdGuardHome.yaml"
 
 #=================================================
 # SETUP SYSTEMD
@@ -199,7 +199,7 @@ ynh_add_systemd_config
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add $app --description="Ads & trackers blocking DNS server" --needs_exposed_ports $adguard_port
+yunohost service add "$app" --description="Ads & trackers blocking DNS server" --needs_exposed_ports $adguard_port
 
 #=================================================
 # START SYSTEMD SERVICE
@@ -207,7 +207,7 @@ yunohost service add $app --description="Ads & trackers blocking DNS server" --n
 ynh_script_progression --message="Starting a systemd service..." --weight=2
 
 # Start a systemd service
-ynh_systemd_action --service_name=$app --action="restart" --log_path=systemd
+ynh_systemd_action --service_name="$app" --action="restart" --log_path=systemd
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/remove
+++ b/scripts/remove
@@ -16,10 +16,10 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 
 app=$YNH_APP_INSTANCE_NAME
 
-domain=$(ynh_app_setting_get --app=$app --key=domain)
-port=$(ynh_app_setting_get --app=$app --key=port)
-final_path=$(ynh_app_setting_get --app=$app --key=final_path)
-adguard_port=$(ynh_app_setting_get --app=$app --key=adguard_port)
+domain=$(ynh_app_setting_get --app="$app" --key=domain)
+port=$(ynh_app_setting_get --app="$app" --key=port)
+final_path=$(ynh_app_setting_get --app="$app" --key=final_path)
+adguard_port=$(ynh_app_setting_get --app="$app" --key=adguard_port)
 
 #=================================================
 # STANDARD REMOVE
@@ -28,10 +28,10 @@ adguard_port=$(ynh_app_setting_get --app=$app --key=adguard_port)
 #=================================================
 
 # Remove the service from the list of services known by YunoHost (added from `yunohost service add`)
-if ynh_exec_warn_less yunohost service status $app >/dev/null
+if ynh_exec_warn_less yunohost service status "$app" >/dev/null
 then
 	ynh_script_progression --message="Removing $app service integration..." --weight=1
-	yunohost service remove $app
+	yunohost service remove "$app"
 fi
 
 #=================================================
@@ -73,7 +73,7 @@ ynh_remove_app_dependencies
 if yunohost firewall list | grep -q "\- $adguard_port$"
 then
 	ynh_script_progression --message="Closing port $adguard_port..." --weight=1
-	ynh_exec_warn_less yunohost firewall disallow TCP $adguard_port
+	ynh_exec_warn_less yunohost firewall disallow TCP "$adguard_port"
 fi
 
 #=================================================
@@ -82,7 +82,7 @@ fi
 ynh_script_progression --message="Removing the dedicated system user..." --weight=1
 
 # Delete a system user
-ynh_system_user_delete --username=$app
+ynh_system_user_delete --username="$app"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/restore
+++ b/scripts/restore
@@ -27,17 +27,17 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 
 app=$YNH_APP_INSTANCE_NAME
 
-domain=$(ynh_app_setting_get --app=$app --key=domain)
-path_url=$(ynh_app_setting_get --app=$app --key=path)
-final_path=$(ynh_app_setting_get --app=$app --key=final_path)
-adguard_port=$(ynh_app_setting_get --app=$app --key=adguard_port)
+domain=$(ynh_app_setting_get --app="$app" --key=domain)
+path_url=$(ynh_app_setting_get --app="$app" --key=path)
+final_path=$(ynh_app_setting_get --app="$app" --key=final_path)
+adguard_port=$(ynh_app_setting_get --app="$app" --key=adguard_port)
 
 #=================================================
 # CHECK IF THE APP CAN BE RESTORED
 #=================================================
 ynh_script_progression --message="Validating restoration parameters..." --weight=1
 
-test ! -d $final_path \
+test ! -d "$final_path" \
 	|| ynh_die --message="There is already a directory: $final_path "
 
 #=================================================
@@ -48,7 +48,7 @@ test ! -d $final_path \
 ynh_script_progression --message="Recreating the dedicated system user..." --weight=1
 
 # Create the dedicated user (if not existing)
-ynh_system_user_create --username=$app --home_dir="$final_path"
+ynh_system_user_create --username="$app" --home_dir="$final_path"
 
 #=================================================
 # RESTORE THE APP MAIN DIR
@@ -60,13 +60,33 @@ ynh_restore_file --origin_path="$final_path"
 # this will be treated as a security issue.
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
-chown -R $app:$app "$final_path"
+chown -R "$app":"$app" "$final_path"
 
-setcap 'CAP_NET_BIND_SERVICE=+eip CAP_NET_RAW=+eip' $final_path/AdGuardHome
+setcap 'CAP_NET_BIND_SERVICE=+eip CAP_NET_RAW=+eip' "$final_path"/AdGuardHome
 
 ynh_restore_file --origin_path="/etc/dnsmasq.d/$app"
 
 systemctl restart dnsmasq
+
+#=================================================
+# DOWNLOAD, CHECK AND UNPACK SOURCE
+#=================================================
+
+# compare if the system arch is different from the binary arch
+# if so, download the correct binary
+if [ "$(uname -m)" != "$(file "$final_path"/AdGuardHome | cut -d ',' -f 2 | tr -d ' ')" ]
+then
+	ynh_script_progression --message="Upgrading source files..." --weight=1
+
+	# Download, check integrity, uncompress and patch the source from app.src
+	ynh_setup_source --dest_dir="$final_path" --source_id="$YNH_ARCH"
+fi
+
+chmod 750 "$final_path"
+chmod -R o-rwx "$final_path"
+chown -R "$app":"$app" "$final_path"
+
+setcap 'CAP_NET_BIND_SERVICE=+eip CAP_NET_RAW=+eip' "$final_path"/AdGuardHome
 
 #=================================================
 # SPECIFIC RESTORATION
@@ -76,7 +96,7 @@ systemctl restart dnsmasq
 ynh_script_progression --message="Reinstalling dependencies..." --weight=1
 
 # Define and install dependencies
-ynh_install_app_dependencies $pkg_dependencies
+ynh_install_app_dependencies "$pkg_dependencies"
 
 #=================================================
 # RESTORE THE NGINX CONFIGURATION
@@ -91,21 +111,21 @@ ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 ynh_script_progression --message="Restoring the systemd configuration..." --weight=1
 
 ynh_restore_file --origin_path="/etc/systemd/system/$app.service"
-systemctl enable $app.service --quiet
+systemctl enable "$app.service" --quiet
 
 #=================================================
 # INTEGRATE SERVICE IN YUNOHOST
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add $app --description="Ads & trackers blocking DNS server" --needs_exposed_ports $adguard_port
+yunohost service add "$app" --description="Ads & trackers blocking DNS server" --needs_exposed_ports "$adguard_port"
 
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="restart" --log_path="systemd"
+ynh_systemd_action --service_name="$app" --action="restart" --log_path="systemd"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -16,14 +16,14 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 
 app=$YNH_APP_INSTANCE_NAME
 
-domain=$(ynh_app_setting_get --app=$app --key=domain)
-path_url=$(ynh_app_setting_get --app=$app --key=path)
-admin=$(ynh_app_setting_get --app=$app --key=admin)
-password=$(ynh_app_setting_get --app=$app --key=password)
-final_path=$(ynh_app_setting_get --app=$app --key=final_path)
-port=$(ynh_app_setting_get --app=$app --key=port)
-adguard_port=$(ynh_app_setting_get --app=$app --key=adguard_port)
-dns_over_https=$(ynh_app_setting_get --app=$app --key=dns_over_https)
+domain=$(ynh_app_setting_get --app="$app" --key=domain)
+path_url=$(ynh_app_setting_get --app="$app" --key=path)
+admin=$(ynh_app_setting_get --app="$app" --key=admin)
+password=$(ynh_app_setting_get --app="$app" --key=password)
+final_path=$(ynh_app_setting_get --app="$app" --key=final_path)
+port=$(ynh_app_setting_get --app="$app" --key=port)
+adguard_port=$(ynh_app_setting_get --app="$app" --key=adguard_port)
+dns_over_https=$(ynh_app_setting_get --app="$app" --key=dns_over_https)
 
 #=================================================
 # CHECK VERSION
@@ -54,11 +54,11 @@ ynh_abort_if_errors
 #=================================================
 ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="stop"
+ynh_systemd_action --service_name="$app" --action="stop"
 
 # Disable the port 53 for upnp
-ynh_exec_warn_less yunohost firewall allow --no-upnp TCP $adguard_port
-ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $adguard_port
+ynh_exec_warn_less yunohost firewall allow --no-upnp TCP "$adguard_port"
+ynh_exec_warn_less yunohost firewall allow --no-upnp UDP "$adguard_port"
 
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
@@ -69,13 +69,13 @@ ynh_script_progression --message="Ensuring downward compatibility..." --weight=1
 if ynh_legacy_permissions_exists; then
 	ynh_legacy_permissions_delete_all
 
-	ynh_app_setting_delete --app=$app --key=is_public
+	ynh_app_setting_delete --app="$app" --key=is_public
 fi
 
 # The dns port should be 53
 if [ "$adguard_port" -ne "53" ]; then
 	adguard_port=53
-	ynh_app_setting_set --app=$app --key=adguard_port --value=$adguard_port
+	ynh_app_setting_set --app="$app" --key=adguard_port --value="$adguard_port"
 fi
 
 # Create a permission if needed
@@ -86,20 +86,20 @@ fi
 if [ -n "$dns_over_https" ] && [ "$dns_over_https" == "1" ];
 then
 	dns_over_https="true"
-	ynh_app_setting_set --app=$app --key=dns_over_https --value=$dns_over_https
+	ynh_app_setting_set --app="$app" --key=dns_over_https --value=$dns_over_https
 	# DNS over TLS
     	adguard_DoT_port=853
-    	ynh_app_setting_set --app=$app --key=adguard_DoT_port --value=$adguard_DoT_port
+    	ynh_app_setting_set --app="$app" --key=adguard_DoT_port --value=$adguard_DoT_port
 	ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $adguard_DoT_port
 	ynh_exec_warn_less yunohost firewall allow --no-upnp TCP $adguard_DoT_port
 	# DNS over QUIC
     	adguard_DoQ_port=784
-	ynh_app_setting_set --app=$app --key=adguard_DoQ_port --value=$adguard_DoQ_port
+	ynh_app_setting_set --app="$app" --key=adguard_DoQ_port --value=$adguard_DoQ_port
 	ynh_exec_warn_less yunohost firewall allow --no-upnp UDP $adguard_DoQ_port
 elif [ -z "$dns_over_https" ] || [ "$dns_over_https" == "0" ];
 then
 	dns_over_https="false"
-	ynh_app_setting_set --app=$app --key=dns_over_https --value=$dns_over_https
+	ynh_app_setting_set --app="$app" --key=dns_over_https --value=$dns_over_https
 fi
 
 #=================================================
@@ -108,7 +108,7 @@ fi
 ynh_script_progression --message="Making sure dedicated system user exists..." --weight=1
 
 # Create a dedicated user (if not existing)
-ynh_system_user_create --username=$app --home_dir="$final_path" --groups="ssl-cert"
+ynh_system_user_create --username="$app" --home_dir="$final_path" --groups="ssl-cert"
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
@@ -119,21 +119,21 @@ then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir=$final_path --source_id="$YNH_ARCH"
+	ynh_setup_source --dest_dir="$final_path" --source_id="$YNH_ARCH"
 fi
 
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
-chown -R $app:$app "$final_path"
+chown -R "$app":"$app" "$final_path"
 
-setcap 'CAP_NET_BIND_SERVICE=+eip CAP_NET_RAW=+eip' $final_path/AdGuardHome
+setcap 'CAP_NET_BIND_SERVICE=+eip CAP_NET_RAW=+eip' "$final_path"/AdGuardHome
 
 #=================================================
 # UPGRADE DEPENDENCIES
 #=================================================
 ynh_script_progression --message="Upgrading dependencies..." --weight=1
 
-ynh_install_app_dependencies $pkg_dependencies
+ynh_install_app_dependencies "$pkg_dependencies"
 
 #=================================================
 # NGINX CONFIGURATION
@@ -175,18 +175,18 @@ ipv4_route_output=$(echo "$(ip -4 route get 1.2.3.4 2> /dev/null)" | head -n1)
 ipv6_route_output=$(echo "$(ip -6 route get ::1.2.3.4 2> /dev/null)" | head -n1)
 
 ipv4_addr=""
-for i in $(seq "$(echo $ipv4_route_output | wc -w)" -1 1); do
-		ip=$(echo $ipv4_route_output | awk "{print \$$i}")
-		if ynh_validate_ip4 --ip_address=$ip; then
+for i in $(seq "$(echo "$ipv4_route_output" | wc -w)" -1 1); do
+		ip=$(echo "$ipv4_route_output" | awk "{print \$$i}")
+		if ynh_validate_ip4 --ip_address="$ip"; then
 				ipv4_addr="$ip"
 				break
 		fi
 done
 
 ipv6_addr=""
-for i in $(seq "$(echo $ipv6_route_output | wc -w)" -1 1); do
-		ip=$(echo $ipv6_route_output | awk "{print \$$i}")
-		if ynh_validate_ip6 --ip_address=$ip; then
+for i in $(seq "$(echo "$ipv6_route_output" | wc -w)" -1 1); do
+		ip=$(echo "$ipv6_route_output" | awk "{print \$$i}")
+		if ynh_validate_ip6 --ip_address="$ip"; then
 				ipv6_addr="$ip"
 				break
 		fi
@@ -217,7 +217,7 @@ if need_file_update:
 "
 
 chmod 600 "$final_path/AdGuardHome.yaml"
-chown -R $app:$app "$final_path/AdGuardHome.yaml"
+chown -R "$app":"$app" "$final_path/AdGuardHome.yaml"
 
 #=================================================
 # SETUP SYSTEMD
@@ -232,14 +232,14 @@ ynh_add_systemd_config
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --weight=1
 
-yunohost service add $app --description="Ads & trackers blocking DNS server" --needs_exposed_ports $adguard_port
+yunohost service add "$app" --description="Ads & trackers blocking DNS server" --needs_exposed_ports "$adguard_port"
 
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="restart" --log_path="systemd"
+ynh_systemd_action --service_name="$app" --action="restart" --log_path="systemd"
 
 #=================================================
 # RELOAD NGINX


### PR DESCRIPTION
## Problem

- new version : v0.107.37
- [the restoration fails if the new CPU architecture don't match the previous one](https://forum.yunohost.org/t/gotosocial-a-fediverse-server-written-in-golang/19160/46?u=oniricorpe) (Similar to https://github.com/YunoHost-Apps/gotosocial_ynh/pull/98)
- some variables aren't quoted

## Solution

- update to v0.107.37 #124
- permit arch migration 5c7e58b6aa6405f38135a2abd7866246ef5403f4
- quoting some variables for security reason 5c7e58b6aa6405f38135a2abd7866246ef5403f4

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
