### PR TITLE
add api (and rename the old "api" to "doh") in [resources.permissions]

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -77,7 +77,12 @@ api.allowed = "visitors"
 api.auth_header = false
 api.protected = true
 api.show_tile = false
-api.url = "re:__DOMAIN__/dns-query"
+api.url = "re:__DOMAIN__/control"
+doh.allowed = "visitors"
+doh.auth_header = false
+doh.protected = true
+doh.show_tile = false
+doh.url = "re:__DOMAIN__/dns-query"
 main.url = "/"
 
 [resources.apt]


### PR DESCRIPTION
## Problem

- when adguard home is not enabled in the visitor group, the API is SSOed

## Solution

- in the manifest.toml:
  - rename the existing "api" to "doh" (because it's related to DoH and not the AGH's API)
  - add the API path `/control`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)