### PR TITLE
disabling the auto-update API point

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -29,3 +29,9 @@ location /dns-query {
   proxy_connect_timeout  6s;
   proxy_pass        http://127.0.0.1:__PORT__/dns-query;
 }
+
+# disabling the API point of the built-in updater (which can break the installation)
+# so the user must update using the YNH package
+location __PATH__/control/update {
+  return 403;
+}


### PR DESCRIPTION
## Problem

- Once, I tried to update my AGH using the built-in auto-updater, and that completely broke my AGH and I haven't figured out how to fix

## Solution

- So, better disabling it, it’s kinda useless with YNH tho

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)