### PR TITLE
Testing v0.107.59

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It operates as a DNS server that re-routes tracking domains to a "black hole", t
 However, Dnsmasq is not disabled and will continue to function as the *localhost DNS server*.
 
 
-**Shipped version:** 0.107.58~ynh1
+**Shipped version:** 0.107.59~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -26,7 +26,7 @@ It operates as a DNS server that re-routes tracking domains to a "black hole", t
 However, Dnsmasq is not disabled and will continue to function as the *localhost DNS server*.
 
 
-**Versión actual:** 0.107.58~ynh1
+**Versión actual:** 0.107.59~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -26,7 +26,7 @@ It operates as a DNS server that re-routes tracking domains to a "black hole", t
 However, Dnsmasq is not disabled and will continue to function as the *localhost DNS server*.
 
 
-**Paketatutako bertsioa:** 0.107.58~ynh1
+**Paketatutako bertsioa:** 0.107.59~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -26,7 +26,7 @@ Il fonctionne comme un serveur DNS qui redirige les domaines de pistage vers un 
 Cependant, Dnsmasq n'est pas désactivé et continuera à fonctionner en tant que *serveur DNS localhost*.
 
 
-**Version incluse :** 0.107.58~ynh1
+**Version incluse :** 0.107.59~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -26,7 +26,7 @@ It operates as a DNS server that re-routes tracking domains to a "black hole", t
 However, Dnsmasq is not disabled and will continue to function as the *localhost DNS server*.
 
 
-**Versión proporcionada:** 0.107.58~ynh1
+**Versión proporcionada:** 0.107.59~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -26,7 +26,7 @@ It operates as a DNS server that re-routes tracking domains to a "black hole", t
 However, Dnsmasq is not disabled and will continue to function as the *localhost DNS server*.
 
 
-**Versi terkirim:** 0.107.58~ynh1
+**Versi terkirim:** 0.107.59~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -26,7 +26,7 @@ It operates as a DNS server that re-routes tracking domains to a "black hole", t
 However, Dnsmasq is not disabled and will continue to function as the *localhost DNS server*.
 
 
-**Geleverde versie:** 0.107.58~ynh1
+**Geleverde versie:** 0.107.59~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -26,7 +26,7 @@ It operates as a DNS server that re-routes tracking domains to a "black hole", t
 However, Dnsmasq is not disabled and will continue to function as the *localhost DNS server*.
 
 
-**Dostarczona wersja:** 0.107.58~ynh1
+**Dostarczona wersja:** 0.107.59~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -26,7 +26,7 @@ It operates as a DNS server that re-routes tracking domains to a "black hole", t
 However, Dnsmasq is not disabled and will continue to function as the *localhost DNS server*.
 
 
-**Поставляемая версия:** 0.107.58~ynh1
+**Поставляемая версия:** 0.107.59~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -26,7 +26,7 @@ It operates as a DNS server that re-routes tracking domains to a "black hole", t
 However, Dnsmasq is not disabled and will continue to function as the *localhost DNS server*.
 
 
-**分发版本：** 0.107.58~ynh1
+**分发版本：** 0.107.59~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ description.fr = "Serveur DNS, bloqueur de publicités et trackers"
 id = "adguardhome"
 name = "AdGuard Home"
 
-version = "0.107.58~ynh1"
+version = "0.107.59~ynh1"
 
 maintainers = [ "ddataa", "OniriCorpe" ]
 
@@ -66,14 +66,14 @@ type = "boolean"
 
 [resources]
     [resources.sources.main]
-    i386.sha256 = "564a373b56cfe0d5cbf4ffc0a51cd0f51e0868afd431bd05b0f8a2897582a7b2"
-    i386.url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.58/AdGuardHome_linux_386.tar.gz"
-    amd64.sha256 = "ae834bbbd9693b5cb8536ae2256394306b74910314f839ad79b0a3ca86c1cd86"
-    amd64.url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.58/AdGuardHome_linux_amd64.tar.gz"
-    arm64.sha256 = "7ffd284e8bc8cfab02e678cac63dad5bda940132a24534fbea0b30b07ac092a0"
-    arm64.url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.58/AdGuardHome_linux_arm64.tar.gz"
-    armhf.sha256 = "a7659a7390e8a5ee83f9e3ad8c65437504e7d8f1f5ab79c8bc67f4e45923e624"
-    armhf.url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.58/AdGuardHome_linux_armv7.tar.gz"
+    i386.sha256 = "f25c8e3021cb0e849d8ceb2b060d5fa0511b1edb2a7094b706a6bfbcf482a4f5"
+    i386.url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.59/AdGuardHome_linux_386.tar.gz"
+    amd64.sha256 = "47af673fed365e2704854c6aadcd2c23913411e76efce31b7bcf16755bb80797"
+    amd64.url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.59/AdGuardHome_linux_amd64.tar.gz"
+    arm64.sha256 = "efc7d2e7e0507af1269f36f9f04274f9097fa3fe0ae1f0c18d2be586ff452c5c"
+    arm64.url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.59/AdGuardHome_linux_arm64.tar.gz"
+    armhf.sha256 = "c0ae9af3587fd324cec18b0ee04213902fb3cd268597087ea7cfb71aab8e21a0"
+    armhf.url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.59/AdGuardHome_linux_armv7.tar.gz"
     in_subdir = 2
 
     autoupdate.asset.i386 = "^AdGuardHome_linux_386.tar.gz$"


### PR DESCRIPTION
Upgrade sources
- `main` v0.107.59: https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.59

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
